### PR TITLE
Add manual testing for add command in dg

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -482,7 +482,7 @@ testers are expected to do more *exploratory* testing.
     1. Test case: `add `<br>
        Expected: No item is added. Error details shown in the status message.
 
-    1. Other incorrect delete commands to try: `add n/`, `add l/kitchen`, `...` (where compulsory fields are not specified)<br>
+    1. Other incorrect add commands to try: `add n/`, `add l/kitchen`, `...` (where compulsory fields are not specified)<br>
        Expected: Similar to previous.
 
        

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -469,8 +469,23 @@ testers are expected to do more *exploratory* testing.
     1. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
        Expected: Similar to previous.
 
-1. _{ more test cases …​ }_
+### Adding an item
 
+1. Adding an item to StoreMando
+
+    1. Prerequisites: Arguments are valid and compulsory parameters are provided. No duplicate item or similar item 
+       exists in the list.
+
+    1. Test case: `add n/Banana q/1 l/kitchen e/2020-10-10 `<br>
+       Expected: Item is added into the displayed list. Details of the added item shown in the status message.
+
+    1. Test case: `add `<br>
+       Expected: No item is added. Error details shown in the status message.
+
+    1. Other incorrect delete commands to try: `add n/`, `add l/kitchen`, `...` (where compulsory fields are not specified)<br>
+       Expected: Similar to previous.
+
+       
 ### Saving data
 
 1. Dealing with missing/corrupted data files


### PR DESCRIPTION
Add test cases that developers can use for manual testing of add command as well as expected behavior of StoreMando.