### PR TITLE
Fix ReminderCommandParser bug

### DIFF
--- a/src/main/java/seedu/storemando/logic/parser/ReminderCommandParser.java
+++ b/src/main/java/seedu/storemando/logic/parser/ReminderCommandParser.java
@@ -32,7 +32,7 @@ public class ReminderCommandParser implements Parser<ReminderCommand> {
             }
 
             String[] wordsInTrimmedArgs = trimmedArgs.replaceAll("\\s{2,}", " ").split(" ");
-            if (!isNumber(wordsInTrimmedArgs[0])) {
+            if (!isNumber(wordsInTrimmedArgs[0]) || wordsInTrimmedArgs.length > 2) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ReminderCommand.MESSAGE_USAGE));
             }
 

--- a/src/test/java/seedu/storemando/logic/parser/ReminderCommandParserTest.java
+++ b/src/test/java/seedu/storemando/logic/parser/ReminderCommandParserTest.java
@@ -80,6 +80,12 @@ public class ReminderCommandParserTest {
         // integer provided greater than maximum integer
         assertParseFailure(parser, "9223372036854775810 days", ReminderCommand.MESSAGE_INCORRECT_INTEGER);
         assertParseFailure(parser, "-9223372036854775810 weeks", ReminderCommand.MESSAGE_INCORRECT_INTEGER);
+
+        // irrelevant trailing words
+        assertParseFailure(parser, "2 days chocolate",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ReminderCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "2 weeks chocolate",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ReminderCommand.MESSAGE_USAGE));
     }
 
 }


### PR DESCRIPTION
1. Detect trailing words behind a valid input (e.g. "reminder 2 days testing") and display error message
2. Add tests for this case
Closes #310 