### PR TITLE
Standardise messages in command classes

### DIFF
--- a/src/main/java/seedu/storemando/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/AddCommand.java
@@ -18,7 +18,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an item to the storemando. \n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an item to the inventory. \n"
         + "Parameters: "
         + PREFIX_NAME + "NAME "
         + PREFIX_LOCATION + "LOCATION "
@@ -34,7 +34,7 @@ public class AddCommand extends Command {
         + PREFIX_TAG + "expiring";
 
     public static final String MESSAGE_SUCCESS = "New item added: %1$s.";
-    public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in the storemando.";
+    public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in the inventory.";
     public static final String MESSAGE_ITEM_EXPIRED_WARNING = "\nWarning: Item has already expired!";
     public static final String MESSAGE_SIMILAR_ITEM_WARNING = "\nWarning: Similar item exists in the same location!";
 

--- a/src/main/java/seedu/storemando/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/DeleteCommand.java
@@ -22,7 +22,7 @@ public class DeleteCommand extends Command {
         + "Parameters: INDEX (must be a positive integer)\n"
         + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_ITEM_SUCCESS = "Deleted Item: %1$s";
+    public static final String MESSAGE_DELETE_ITEM_SUCCESS = "Deleted item: %1$s.";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/storemando/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/EditCommand.java
@@ -48,7 +48,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited item: %1$s.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in inventory.";
+    public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in the inventory.";
     public static final String MESSAGE_NO_CHANGE = "Item not edited! Specified change in item details same as "
         + "original.";
     public static final String MESSAGE_ITEM_EXPIRED_WARNING = "\nWarning: Item has already expired!";

--- a/src/main/java/seedu/storemando/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/EditCommand.java
@@ -46,9 +46,9 @@ public class EditCommand extends Command {
         + PREFIX_QUANTITY + "5 "
         + PREFIX_EXPIRYDATE + "2018-10-10";
 
-    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited Item: %1$s";
+    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited item: %1$s.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in storemando.";
+    public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists in inventory.";
     public static final String MESSAGE_NO_CHANGE = "Item not edited! Specified change in item details same as "
         + "original.";
     public static final String MESSAGE_ITEM_EXPIRED_WARNING = "\nWarning: Item has already expired!";

--- a/src/main/java/seedu/storemando/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Location Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting storemando as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/storemando/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting storemando as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting StoreMando as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/storemando/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/ListCommand.java
@@ -24,9 +24,9 @@ public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_SUCCESS = "Listed all items.";
-    public static final String MESSAGE_SUCCESS_TAG_PREDICATE = "Listed all items with the following tag %s";
-    public static final String MESSAGE_SUCCESS_LOCATION_PREDICATE = "Listed all items located in %s";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": List items in the storemando.\n"
+    public static final String MESSAGE_SUCCESS_TAG_PREDICATE = "Listed all items with the following tag %s.";
+    public static final String MESSAGE_SUCCESS_LOCATION_PREDICATE = "Listed all items located in %s.";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": List items in the inventory.\n"
         + "Parameters: "
         + "[" + PREFIX_LOCATION + "LOCATION] " + "/ [" + PREFIX_TAG + "TAG]\n"
         + "Example:\n"

--- a/src/main/java/seedu/storemando/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/ListCommand.java
@@ -28,7 +28,7 @@ public class ListCommand extends Command {
         + "tag %s (if the tag exists).";
     public static final String MESSAGE_SUCCESS_LOCATION_PREDICATE = "Listed all items located in %s "
         + "(if the location exists).";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": List items in the the inventory.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": List items in the inventory.\n"
         + "Parameters: "
         + "[" + PREFIX_LOCATION + "LOCATION] " + "/ [" + PREFIX_TAG + "TAG]\n"
         + "Example:\n"

--- a/src/main/java/seedu/storemando/logic/commands/ReminderCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/ReminderCommand.java
@@ -20,14 +20,14 @@ public class ReminderCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters all items whose expiry date is within "
         + "the user-specified number of days/weeks from the current date. \n"
-        + "Parameters: Days/Weeks (must be an integer) [TimeUnitKeyWord] (days/weeks (day/week accepted for -1/0/1))\n"
+        + "Parameters: NUMBER (must be an integer) TIMEUNITKEYWORD (days/weeks (day/week accepted for -1/0/1))\n"
         + "Example: \n1. " + COMMAND_WORD + " 3 days\n2. " + COMMAND_WORD + " 1 week";
 
-    public static final String MESSAGE_SUCCESS_EXPIRING_ITEM = "Display all items that are expiring within %d %s or has"
+    public static final String MESSAGE_SUCCESS_EXPIRING_ITEM = "Filtered all items that are expiring within %d %s or has"
         + " already expired.";
-    public static final String MESSAGE_SUCCESS_EXPIRED_ITEM = "Display all items that has been expired for at least"
+    public static final String MESSAGE_SUCCESS_EXPIRED_ITEM = "Filtered all items that has been expired for at least"
         + " %d %s.";
-    public static final String MESSAGE_SUCCESS_EXPIRING_TODAY_ITEM = "Display all items that are expiring today or "
+    public static final String MESSAGE_SUCCESS_EXPIRING_TODAY_ITEM = "Filtered all items that are expiring today or "
         + "has already expired.";
 
     public static final String MESSAGE_INCORRECT_INTEGER = "Number provided must be greater than -366 "

--- a/src/main/java/seedu/storemando/logic/commands/ReminderCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/ReminderCommand.java
@@ -22,9 +22,8 @@ public class ReminderCommand extends Command {
         + "the user-specified number of days/weeks from the current date. \n"
         + "Parameters: NUMBER (must be an integer) TIMEUNITKEYWORD (days/weeks (day/week accepted for -1/0/1))\n"
         + "Example: \n1. " + COMMAND_WORD + " 3 days\n2. " + COMMAND_WORD + " 1 week";
-
-    public static final String MESSAGE_SUCCESS_EXPIRING_ITEM = "Filtered all items that are expiring within %d %s or has"
-        + " already expired.";
+    public static final String MESSAGE_SUCCESS_EXPIRING_ITEM = "Filtered all items that are expiring within %d %s or "
+        + "has already expired.";
     public static final String MESSAGE_SUCCESS_EXPIRED_ITEM = "Filtered all items that has been expired for at least"
         + " %d %s.";
     public static final String MESSAGE_SUCCESS_EXPIRING_TODAY_ITEM = "Filtered all items that are expiring today or "

--- a/src/main/java/seedu/storemando/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/SortCommand.java
@@ -8,7 +8,7 @@ public abstract class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-        + ": Sorts the items in StoreMando by quantity or expiry date.\n"
+        + ": Sorts the items in the inventory by quantity or expiry date.\n"
         + "Parameters (case-insensitive): quantity asc, quantity desc OR expirydate\n"
         + "Examples: \n"
         + "1. " + COMMAND_WORD + " quantity asc\n"

--- a/src/main/java/seedu/storemando/logic/commands/SortExpiryDateCommand.java
+++ b/src/main/java/seedu/storemando/logic/commands/SortExpiryDateCommand.java
@@ -11,7 +11,7 @@ import seedu.storemando.model.item.Item;
 import seedu.storemando.model.item.comparator.ItemComparatorByExpiryDate;
 
 public class SortExpiryDateCommand extends SortCommand {
-    public static final String MESSAGE_SUCCESS_EXPIRYDATE_ASC = "Sorted all items based on their expiry date in an"
+    public static final String MESSAGE_SUCCESS_EXPIRYDATE_ASC = "Sorted all items based on their expiry date in"
         + " chronological order.";
 
     @Override


### PR DESCRIPTION
1. Rephrase certain success messages and added punctuation marks to the end of the messages.
2. Rephrase certain command usage messages (i.e. ReminderCommand)
3. Replace all "storemando" with "inventory" in messages

Close #331 